### PR TITLE
Add blobContentType mimetype

### DIFF
--- a/src/services/azure-file-blob-storage.ts
+++ b/src/services/azure-file-blob-storage.ts
@@ -47,7 +47,11 @@ class AzureBlobStorageFileService extends AbstractFileService {
 
         const blockBlobClient = containerClient.getBlockBlobClient(filename)
 
-        await blockBlobClient.uploadStream(fs.createReadStream(file.path));
+        await blockBlobClient.uploadStream(fs.createReadStream(file.path), undefined, undefined, {
+            blobHTTPHeaders: {
+                blobContentType: file.mimetype
+            }
+        });
 
         return { url: blockBlobClient.url, key: filename };
     }
@@ -61,8 +65,12 @@ class AzureBlobStorageFileService extends AbstractFileService {
   
         const blockBlobClient = containerClient.getBlockBlobClient(filename)
   
-        await blockBlobClient.uploadStream(fs.createReadStream(file.path));
-  
+        await blockBlobClient.uploadStream(fs.createReadStream(file.path), undefined, undefined, {
+            blobHTTPHeaders: {
+                blobContentType: file.mimetype
+            }
+        });
+
         return { url: blockBlobClient.url, key: filename };
     }
 


### PR DESCRIPTION
Explicitly setting the blob Content-Type metadata.

When you upload files to Azure Blob Storage, the Content-Type tells browsers how to handle the file.

If the Content-Type is set to `image/png`, `image/jpeg`, or another appropriate image MIME type, 
then the browser will display the image directly.

However, if the Content-Type is missing or incorrectly set, _e.g._ `application/octet-stream`,
then the browser will treat the file as a download.

This matches the source code and behaviour of the plugin `medusa-file-s3` for AWS S3 Bucket.